### PR TITLE
Issue 9 animation curve optimization

### DIFF
--- a/Editor/LoweffortUploader_AnimationUtility.cs
+++ b/Editor/LoweffortUploader_AnimationUtility.cs
@@ -11,14 +11,14 @@ namespace PaLASOLU
 {
 	public partial class LoweffortUploaderCore : Plugin<LoweffortUploaderCore>
 	{
-		private sealed class CurveAccumulator
+		private sealed class FloatCurveAccumulator
 		{
 			public readonly List<Keyframe> Keys = new List<Keyframe>();
 			public readonly HashSet<float> KeyTimes = new HashSet<float>();
 			public readonly WrapMode PreWrapMode;
 			public readonly WrapMode PostWrapMode;
 
-			public CurveAccumulator(AnimationCurve sourceCurve)
+			public FloatCurveAccumulator(AnimationCurve sourceCurve)
 			{
 				PreWrapMode = sourceCurve.preWrapMode;
 				PostWrapMode = sourceCurve.postWrapMode;
@@ -52,7 +52,7 @@ namespace PaLASOLU
 				legacy = false
 			};
 
-			Dictionary<EditorCurveBinding, CurveAccumulator> curveAccumulators = new Dictionary<EditorCurveBinding, CurveAccumulator>();
+			Dictionary<EditorCurveBinding, FloatCurveAccumulator> curveAccumulators = new Dictionary<EditorCurveBinding, FloatCurveAccumulator>();
 			Dictionary<EditorCurveBinding, List<ObjectReferenceKeyframe>> objectCurveAccumulators = new Dictionary<EditorCurveBinding, List<ObjectReferenceKeyframe>>();
 
 			foreach (TimelineClip clip in timelineClips)
@@ -133,9 +133,9 @@ namespace PaLASOLU
 					List<Keyframe> validKeys = allKeys.Where(k => k.time <= endTime).ToList();
 					newCurve.keys = validKeys.ToArray();
 
-					if (!curveAccumulators.TryGetValue(binding, out CurveAccumulator accumulator))
+					if (!curveAccumulators.TryGetValue(binding, out FloatCurveAccumulator accumulator))
 					{
-						accumulator = new CurveAccumulator(curve);
+						accumulator = new FloatCurveAccumulator(curve);
 						curveAccumulators.Add(binding, accumulator);
 					}
 
@@ -181,9 +181,9 @@ namespace PaLASOLU
 			EditorCurveBinding[] mergedBindings = new EditorCurveBinding[curveAccumulators.Count];
 			AnimationCurve[] mergedCurves = new AnimationCurve[curveAccumulators.Count];
 			int curveIndex = 0;
-			foreach (KeyValuePair<EditorCurveBinding, CurveAccumulator> pair in curveAccumulators)
+			foreach (KeyValuePair<EditorCurveBinding, FloatCurveAccumulator> pair in curveAccumulators)
 			{
-				CurveAccumulator accumulator = pair.Value;
+				FloatCurveAccumulator accumulator = pair.Value;
 				AnimationCurve curve = new AnimationCurve
 				{
 					keys = accumulator.Keys.ToArray(),

--- a/Editor/LoweffortUploader_AnimationUtility.cs
+++ b/Editor/LoweffortUploader_AnimationUtility.cs
@@ -11,6 +11,25 @@ namespace PaLASOLU
 {
 	public partial class LoweffortUploaderCore : Plugin<LoweffortUploaderCore>
 	{
+		private sealed class CurveAccumulator
+		{
+			public readonly List<Keyframe> Keys = new List<Keyframe>();
+			public readonly HashSet<float> KeyTimes = new HashSet<float>();
+			public readonly WrapMode PreWrapMode;
+			public readonly WrapMode PostWrapMode;
+
+			public CurveAccumulator(AnimationCurve sourceCurve)
+			{
+				PreWrapMode = sourceCurve.preWrapMode;
+				PostWrapMode = sourceCurve.postWrapMode;
+			}
+
+			public void Add(Keyframe key)
+			{
+				if (KeyTimes.Add(key.time)) Keys.Add(key);
+			}
+		}
+
 		public static AnimationClip BakeAnimationTrackToMergedClip(TrackAsset track)
 		{
 			if (track is not AnimationTrack animationTrack)
@@ -32,6 +51,8 @@ namespace PaLASOLU
 				name = $"{track.name}_Merged",
 				legacy = false
 			};
+
+			Dictionary<EditorCurveBinding, CurveAccumulator> curveAccumulators = new Dictionary<EditorCurveBinding, CurveAccumulator>();
 
 			foreach (TimelineClip clip in timelineClips)
 			{
@@ -111,18 +132,15 @@ namespace PaLASOLU
 					List<Keyframe> validKeys = allKeys.Where(k => k.time <= endTime).ToList();
 					newCurve.keys = validKeys.ToArray();
 
-					AnimationCurve existing = AnimationUtility.GetEditorCurve(mergedClip, binding);
-					if (existing != null)
+					if (!curveAccumulators.TryGetValue(binding, out CurveAccumulator accumulator))
 					{
-						foreach (var key in newCurve.keys)
-						{
-							existing.AddKey(key);
-						}
-						AnimationUtility.SetEditorCurve(mergedClip, binding, existing);
+						accumulator = new CurveAccumulator(curve);
+						curveAccumulators.Add(binding, accumulator);
 					}
-					else
+
+					foreach (Keyframe key in newCurve.keys)
 					{
-						AnimationUtility.SetEditorCurve(mergedClip, binding, newCurve);
+						accumulator.Add(key);
 					}
 				}
 
@@ -163,6 +181,27 @@ namespace PaLASOLU
 
 			}
 
+			EditorCurveBinding[] mergedBindings = new EditorCurveBinding[curveAccumulators.Count];
+			AnimationCurve[] mergedCurves = new AnimationCurve[curveAccumulators.Count];
+			int curveIndex = 0;
+			foreach (KeyValuePair<EditorCurveBinding, CurveAccumulator> pair in curveAccumulators)
+			{
+				CurveAccumulator accumulator = pair.Value;
+				AnimationCurve curve = new AnimationCurve
+				{
+					keys = accumulator.Keys.ToArray(),
+					preWrapMode = accumulator.PreWrapMode,
+					postWrapMode = accumulator.PostWrapMode
+				};
+
+				mergedBindings[curveIndex] = pair.Key;
+				mergedCurves[curveIndex] = curve;
+				curveIndex++;
+			}
+			if (mergedBindings.Length > 0)
+			{
+				AnimationUtility.SetEditorCurves(mergedClip, mergedBindings, mergedCurves);
+			}
 			LogMessageSimplifier.PaLog(0, $"MergedClip generated: {mergedClip.name}");
 			return mergedClip;
 		}

--- a/Editor/LoweffortUploader_AnimationUtility.cs
+++ b/Editor/LoweffortUploader_AnimationUtility.cs
@@ -53,6 +53,7 @@ namespace PaLASOLU
 			};
 
 			Dictionary<EditorCurveBinding, CurveAccumulator> curveAccumulators = new Dictionary<EditorCurveBinding, CurveAccumulator>();
+			Dictionary<EditorCurveBinding, List<ObjectReferenceKeyframe>> objectCurveAccumulators = new Dictionary<EditorCurveBinding, List<ObjectReferenceKeyframe>>();
 
 			foreach (TimelineClip clip in timelineClips)
 			{
@@ -166,17 +167,13 @@ namespace PaLASOLU
 						}
 					}
 
-					ObjectReferenceKeyframe[] existing = AnimationUtility.GetObjectReferenceCurve(mergedClip, binding);
-					if (existing != null && existing.Length > 0)
+					if (!objectCurveAccumulators.TryGetValue(binding, out List<ObjectReferenceKeyframe> accumulator))
 					{
-						//Sort to Time
-						var merged = existing.Concat(newKeys).OrderBy(kf => kf.time).ToArray();
-						AnimationUtility.SetObjectReferenceCurve(mergedClip, binding, merged);
+						accumulator = new List<ObjectReferenceKeyframe>();
+						objectCurveAccumulators.Add(binding, accumulator);
 					}
-					else
-					{
-						AnimationUtility.SetObjectReferenceCurve(mergedClip, binding, newKeys.ToArray());
-					}
+
+					accumulator.AddRange(newKeys);
 				}
 
 			}
@@ -202,6 +199,21 @@ namespace PaLASOLU
 			{
 				AnimationUtility.SetEditorCurves(mergedClip, mergedBindings, mergedCurves);
 			}
+
+			EditorCurveBinding[] mergedObjectBindings = new EditorCurveBinding[objectCurveAccumulators.Count];
+			ObjectReferenceKeyframe[][] mergedObjectCurves = new ObjectReferenceKeyframe[objectCurveAccumulators.Count][];
+			int objectCurveIndex = 0;
+			foreach (KeyValuePair<EditorCurveBinding, List<ObjectReferenceKeyframe>> pair in objectCurveAccumulators)
+			{
+				mergedObjectBindings[objectCurveIndex] = pair.Key;
+				mergedObjectCurves[objectCurveIndex] = pair.Value.OrderBy(key => key.time).ToArray();
+				objectCurveIndex++;
+			}
+			if (mergedObjectBindings.Length > 0)
+			{
+				AnimationUtility.SetObjectReferenceCurves(mergedClip, mergedObjectBindings, mergedObjectCurves);
+			}
+
 			LogMessageSimplifier.PaLog(0, $"MergedClip generated: {mergedClip.name}");
 			return mergedClip;
 		}


### PR DESCRIPTION
## 概要

AnimationTrack の結合時に、カーブをクリップごとに取得・更新していた処理を一括化しました。

Closes #9

## 変更内容

### Float Curve

- binding ごとにキーフレームをメモリ上へ蓄積
- `GetEditorCurve` / `AddKey` / `SetEditorCurve` の反復処理を削減
- 全クリップの処理後に `SetEditorCurves` で一括反映
- 同一時刻のキーは従来どおり先に処理されたキーを保持
- wrap mode、キー生成、範囲フィルタの既存挙動を維持

### Object Reference Curve

- binding ごとにキーフレームをメモリ上へ蓄積
- `GetObjectReferenceCurve` / `Concat` / `SetObjectReferenceCurve` の反復処理を削減
- 最後に時刻順へソートし、`SetObjectReferenceCurves` で一括反映
- Object Reference キーの生成処理は変更なし

## 確認内容

- Unity 2022.3.22f1 同梱コンパイラで対象コードのコンパイルを確認
- カーブの結合順序、同一時刻キーの扱い、wrap mode が従来どおりであることを確認